### PR TITLE
添加“未选中”视图、生成解锁圣遗物对应的 lock.json 的选项

### DIFF
--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -23,6 +23,9 @@
     "Replace": "替换",
     "Import": "导入",
     "Generate": "生成",
+    "All": "全部",
+    "Lock only": "仅加锁",
+    "Unlock only": "仅解锁",
     "Name": "名称",
     "Enabled": "启用",
     "Presets": "预设",
@@ -81,6 +84,8 @@
     "Did you upload it": "你上传了吗",
     "Back to home": "回到主页",
     "No artifact found": "未找到圣遗物",
+    "Selected": "选中",
+    "Unselected": "未选中",
     "Fitness": "匹配度",
     "Rarity": "稀有度",
 

--- a/src/features/Paginator.jsx
+++ b/src/features/Paginator.jsx
@@ -25,7 +25,7 @@ const Paginator = ({ page, setPage, offset, setOffset, totalPages, scrollToId=nu
         «
       </button>
       <select
-        className="btn select btn-ghost select-ghost max-w-xs "
+        className="btn select btn-ghost max-w-xs "
         value={page}
         onChange={(e) => setPage(Number(e.target.value))}
       >

--- a/src/features/artifacts/ArtifactsFilter.jsx
+++ b/src/features/artifacts/ArtifactsFilter.jsx
@@ -14,6 +14,8 @@ const ArtifactsFilter = ({
   setFitness,
   rarity,
   setRarity,
+  isInverted,
+  setIsInverted,
   sortKey,
   setSortKey,
   set,
@@ -79,6 +81,16 @@ const ArtifactsFilter = ({
       </div>
       <div className="my-4 flex w-full flex-col items-center justify-center text-lg text-primary-focus md:flex-row md:space-x-4">
         <div className="flex flex-row items-center space-x-4">
+          <span className="flex flex-row items-center gap-2">
+            {t("Selected")}
+            <input
+              type="checkbox"
+              checked={isInverted}
+              className="toggle toggle-primary"
+              onChange={(e) => setIsInverted(e.target.checked)}
+            />
+            {t("Unselected")}
+          </span>
           <span className="flex flex-row items-center">
             {t("Fitness")}
             {sortKey === "fitness-asc" && (
@@ -121,7 +133,7 @@ const ArtifactsFilter = ({
           </div>
         </div>
       </div>
-      <div className="flex w-full flex-row items-center justify-center text-primary-focus space-x-2">
+      <div className="flex w-full flex-row items-center justify-center text-primary-focus space-x-2 pb-4">
         <span>{t("level", { ns: "artifacts"})}</span>
         <span className="text-lg">{minLevel}</span>
         <MultiRange

--- a/src/features/artifacts/ArtifactsUpload.jsx
+++ b/src/features/artifacts/ArtifactsUpload.jsx
@@ -196,7 +196,7 @@ const ArtifactsUpload = () => {
       }
       return ret;
     },
-    [artifacts, fitness, rarity, allFits, allRarity, set, pos, minLevel, maxLevel]
+    [artifacts, fitness, rarity, allFits, allRarity, set, pos]
   );
   const levelFilterFn = useCallback(
     (idx) => minLevel <= artifacts[idx].level && artifacts[idx].level <= maxLevel,
@@ -233,7 +233,7 @@ const ArtifactsUpload = () => {
     element.download = "lock.json";
     document.body.appendChild(element); // Required for this to work in FireFox
     element.click();
-  }, [selectedArtifacts]);
+  }, [artifacts]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
目前背包里的圣遗物全部都是锁定状态，所以想用这个工具筛选出相对差的做狗粮，用 yas-lock 解锁，腾出一些库存空间。所以添加了分别导出仅加锁、仅解锁、和全部变更对应的 `lock.json` 的按钮。

添加“未选中”视图是为了方便确认要解锁的圣遗物。

![image](https://user-images.githubusercontent.com/16470555/224236751-19518afc-b848-4341-982c-65853e4ce437.png)
