### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/update-genshin-data.yml
+++ b/.github/workflows/update-genshin-data.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm


### PR DESCRIPTION
Updates the Genshin data workflow to newer GitHub action major versions:

- `actions/checkout@v6`
- `actions/setup-node@v6`

This addresses the Node.js 20 action-runtime deprecation annotation emitted by the first workflow run after PR #21 merged.

Validation:
- `$HOME/go/bin/actionlint .github/workflows/update-genshin-data.yml`
- `npx prettier --check .github/workflows/update-genshin-data.yml`
- `git diff --check -- .github/workflows/update-genshin-data.yml`
